### PR TITLE
Introduce RootFile::Add helper

### DIFF
--- a/include/travex/RootFile.h
+++ b/include/travex/RootFile.h
@@ -36,6 +36,15 @@ public:
 
 protected:
 
+   /// Adds HistContainer to the file
+   /// Current implementation is limited to Allocate-Add-Allocate-Add workflow:
+   // \code
+   // Add(new FooContainer("foo"))
+   // Add(new BarContainer("bar"))
+   // \endcode
+   // Allocate-Allocate-Add-Add will produce a wrong directory tree.
+   void Add(HistContainer *hc);
+
    /// Unrestricted access to a stored histogram container by its name for
    /// friends and those who know what they are doing
    HistContainer* hc(const std::string& hc_name) const;

--- a/src/RootFile.cxx
+++ b/src/RootFile.cxx
@@ -92,3 +92,10 @@ void RootFile::SaveAllAs(std::string prefix)
       container->SaveAllAs(path);
    }
 }
+
+
+void RootFile::Add(HistContainer *hc)
+{
+   fDirs.insert({hc->GetName(), hc});
+   cd();
+}


### PR DESCRIPTION
Реализация мягко говоря не очень. Основная проблема в том, что TDirectoryFile не так легко переместить после того как он уже создан. Ссылку в нём самом можно обновить при помощи TDirecotryFile::SetMother, но этого недостаточно, нужно ещё найти и удалить TKey в старом корне и добавить в новый: https://github.com/root-mirror/root/blob/bab1c56dd6cce03cf22d47027adbf0096bd8c7b2/io/io/src/TDirectoryFile.cxx#L137-L162
